### PR TITLE
Import PR merging code from paas-cf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# GithubMergeSign
+# Github Merge & Sign
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/github_merge_sign`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+This is a tool to merge and GPG sign a github pull-request. This replicates the
+functionality of the Github merge button, adding GPG signing.
 
 ## Installation
 
@@ -22,11 +21,14 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+To merge a github PR first change directory to a local checkout of the repo,
+and then run (where N is the github PR number):
+
+    $ bundle exec github_merge_sign --pr N
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
@@ -34,8 +36,6 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/alphagov/paas-github_merge_sign.
 
-
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/exe/github_merge_sign
+++ b/exe/github_merge_sign
@@ -1,3 +1,16 @@
 #!/usr/bin/env ruby
 
+require "optparse"
 require "github_merge_sign"
+
+pr_number = 0
+option_parser = OptionParser.new do |opts|
+  opts.on('--pr   number', Integer) do |value|
+    pr_number = value
+  end
+end
+option_parser.parse!
+
+abort "Must specify PR number" unless pr_number > 0
+
+GithubMergeSign::PullRequest.new(pr_number).merge!

--- a/github_merge_sign.gemspec
+++ b/github_merge_sign.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "webmock", "~> 3.0"
 end

--- a/lib/github_merge_sign.rb
+++ b/lib/github_merge_sign.rb
@@ -1,5 +1,155 @@
+require 'json'
+require 'net/http'
+require 'uri'
+
 require "github_merge_sign/version"
 
 module GithubMergeSign
-  # Your code goes here...
+  class PullRequest
+    BASE_URL = 'https://api.github.com/repos'.freeze
+
+    def initialize(pr_number)
+      @pr_number = pr_number
+    end
+
+    def repo
+      @repo ||= read_repo_from_git
+    end
+
+    def open?
+      details.fetch("state") == "open"
+    end
+
+    def mergeable?
+      !! details.fetch("mergeable")
+    end
+
+    def status_checks_passed?
+      status.fetch("state") == "success" || status.fetch("statuses").empty?
+    end
+
+    def external_pr?
+      details.fetch("base").fetch("repo").fetch("full_name") !=
+        details.fetch("head").fetch("repo").fetch("full_name")
+    end
+
+    def target_branch
+      details.fetch("base").fetch("ref")
+    end
+
+    def head_commit_id
+      details.fetch("head").fetch("sha")
+    end
+
+    def head_ref
+      details.fetch("head").fetch("ref")
+    end
+
+    def commit_message
+      <<-EOT
+Merge pull request ##{@pr_number} from #{details.fetch('head').fetch('user').fetch('login')}/#{head_ref}
+
+#{details.fetch('title')}
+      EOT
+    end
+
+    def merge!
+      raise "PR is not open" unless open?
+      raise "PR is not mergeable" unless mergeable?
+      raise "PR has not passed all status checks" unless status_checks_passed?
+
+      # Check working directorty is clean
+      unless Kernel.system('git diff --quiet --exit-code HEAD')
+        raise "Working directory is not clean. Aborting..."
+      end
+
+      info "Checking out and updating #{target_branch}"
+      execute_command("git checkout #{target_branch}")
+      execute_command("git pull --ff-only origin #{target_branch}")
+
+      if external_pr?
+        info "Fetching commits from PR #{@pr_number}"
+        execute_command("git fetch origin refs/pull/#{@pr_number}/head")
+      end
+
+      info "Merging PR with commit message:\n#{commit_message}"
+      execute_command('git', 'merge', '--no-ff', '-S', '-m', commit_message, head_commit_id)
+
+      info "Pushing to origin"
+      execute_command("git push origin #{target_branch}")
+
+      unless external_pr?
+        info "Deleting remote branch #{head_ref}"
+        execute_command("git push origin :#{head_ref}")
+      end
+
+      info "Done."
+    end
+
+    private
+
+    def read_repo_from_git
+      details = `git remote -v`
+      unless $?.success?
+        raise "Error reading git remotes: exit status #{$?.exitstatus}."
+      end
+      details.each_line do |line|
+        line.strip!
+        if line =~ /\Aorigin\t(\S+)\s+\(fetch\)\z/
+          url = $1
+          if url =~ /\A(?:https:\/\/|git@)github\.com[\/:](\S+?)(?:\.git)?\z/
+            return $1
+          end
+        end
+      end
+      raise "origin is not a Github URL"
+    end
+
+    def execute_command(*args)
+      unless Kernel.system(*args)
+        raise "Error: command '#{args.join(' ')}' exited #{$?.exitstatus}."
+      end
+    end
+
+    def details
+      @_details ||= get_json("#{BASE_URL}/#{repo}/pulls/#{@pr_number}")
+    end
+
+    def status
+      url = "#{BASE_URL}/#{repo}/commits/#{head_commit_id}/status"
+      @_status ||= get_json(url)
+    end
+
+    def get_json(url)
+      response = http_get(url)
+      if response.is_a?(Net::HTTPForbidden) && response.body =~ /API rate limit exceeded for/
+        raise "Github rate-limit exceeded. To avoid this create a Github API token with public access and put it in GITHUB_API_TOKEN env var."
+      end
+
+      unless response.is_a?(Net::HTTPSuccess)
+        raise "Failed to fetch PR details.\nGot #{response.code} fetching '#{url}':\n#{response.body}"
+      end
+
+      JSON.parse(response.body)
+    end
+
+    def http_get(url)
+      uri = URI.parse(url)
+      if ENV["GITHUB_API_TOKEN"]
+        uri.query = [uri.query, "access_token=#{ENV['GITHUB_API_TOKEN']}"].compact.join('&')
+      end
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        request = Net::HTTP::Get.new(uri.request_uri)
+        return http.request(request)
+      end
+    end
+
+    def info(message)
+      if $stdout.isatty
+        puts "\e[36m#{message}\e[0m"
+      else
+        puts message
+      end
+    end
+  end
 end

--- a/spec/pull_request_spec.rb
+++ b/spec/pull_request_spec.rb
@@ -1,0 +1,375 @@
+
+RSpec.describe GithubMergeSign::PullRequest do
+  let(:repo) { "example/test-repo" }
+  let(:pull_request) { GithubMergeSign::PullRequest.new(1) }
+  let(:pr_commit_id) { "12345678901234567890" }
+
+  before :all do
+    # Clear any value set in a user's global environment (eg from .bashrc etc).
+    ENV.delete("GITHUB_API_TOKEN")
+  end
+
+  before :each do
+    allow_any_instance_of(GithubMergeSign::PullRequest).to receive(:info) # silence logging
+
+    allow_any_instance_of(GithubMergeSign::PullRequest).to receive(:`).with('git remote -v') do
+      system("exit 0") # setup $?
+      "origin\tgit@github.com:#{repo} (fetch)\norigin\tgit@github.com:#{repo} (push)\n"
+    end
+  end
+
+  def stub_pr_details(details, options = {})
+    url = "#{GithubMergeSign::PullRequest::BASE_URL}/#{repo}/pulls/1"
+    url << "?access_token=#{options[:token]}" if options[:token]
+    WebMock.stub_request(:get, url)
+      .to_return(
+        headers: { "Content-Type" => "application/json" },
+        body: details.to_json,
+      )
+  end
+
+  it "outputs a useful error message when the API rate limit is hit" do
+    WebMock.stub_request(:get, "#{GithubMergeSign::PullRequest::BASE_URL}/#{repo}/pulls/1")
+      .to_return(
+        status: 403,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          "message" => "API rate limit exceeded for 192.0.2.#{rand(1..254)}. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
+        }.to_json,
+      )
+
+    expect {
+      pull_request.open?
+    }.to raise_error(/Github rate-limit exceeded/)
+  end
+
+  describe "Using authenticated requests when configured" do
+    before :each do
+      ENV["GITHUB_API_TOKEN"] = "1234567890"
+    end
+    after :each do
+      ENV.delete("GITHUB_API_TOKEN")
+    end
+
+    it "should add an access token to API requests" do
+      stub_without_token = stub_pr_details("state" => "open")
+      stub_with_token = stub_pr_details({ "state" => "open" }, token: "1234567890")
+
+      pull_request.open?
+
+      expect(stub_with_token).to have_been_requested
+      expect(stub_without_token).not_to have_been_requested
+    end
+  end
+
+  describe "parsing the github repo from git remotes" do
+    [
+      'https://github.com/user/repo',
+      'https://github.com/user/repo.git',
+      'git@github.com:user/repo',
+      'git@github.com:user/repo.git',
+    ].each do |url|
+      it "correctly parses URLs of the form '#{url}'" do
+        allow(pull_request).to receive(:`).with('git remote -v') do
+          system("exit 0") # setup $?
+          "origin\t#{url} (fetch)\norigin\t#{url} (push)\n"
+        end
+
+        expect(pull_request.repo).to eq("user/repo")
+      end
+    end
+
+    it "ignores non-origin remotes in the list" do
+      allow(pull_request).to receive(:`).with('git remote -v') do
+        system("exit 0") # setup $?
+        output = ""
+        output << "mine\thttps://github.com/mine/repo (fetch)\nmine\thttps://github.com/mine/repo (push)\n"
+        output << "origin\thttps://github.com/user/repo (fetch)\norigin\thttps://github.com/user/repo (push)\n"
+        output << "upstream\thttps://github.com/upstream/repo (fetch)\nupstream\thttps://github.com/upstream/repo (push)\n"
+        output
+      end
+
+      expect(pull_request.repo).to eq("user/repo")
+    end
+
+    it "raises an error when running `git remote` fails" do
+      allow(pull_request).to receive(:`).with('git remote -v') do
+        system("exit 2")
+      end
+      expect {
+        pull_request.repo
+      }.to raise_error(/Error reading git remotes/)
+    end
+
+    it "raises an error when origin is not a github remote" do
+      allow(pull_request).to receive(:`).with('git remote -v') do
+        system("exit 0") # setup $?
+        "origin\thttps://somewhere.com/user/repo (fetch)\norigin\thttps://somewhere.com/user/repo (push)\n"
+      end
+
+      expect {
+        pull_request.repo
+      }.to raise_error(/origin is not a Github URL/)
+    end
+  end
+
+  describe "open?" do
+    it "is true if the PR is open" do
+      stub_pr_details("state" => "open")
+      expect(pull_request.open?).to eq(true)
+    end
+
+    it "is false otherwise" do
+      stub_pr_details("state" => "closed")
+      expect(pull_request.open?).to eq(false)
+    end
+  end
+
+  describe "mergeable?" do
+    it "is false when Github reports the PR as not mergable" do
+      stub_pr_details("mergeable" => false)
+      expect(pull_request.mergeable?).to eq(false)
+    end
+
+    it "is false when Github hasn't computed the mergability yet" do
+      stub_pr_details("mergeable" => nil)
+      expect(pull_request.mergeable?).to eq(false)
+    end
+
+    it "is true when Github reports the PR as mergeable" do
+      stub_pr_details("mergeable" => true)
+      expect(pull_request.mergeable?).to eq(true)
+    end
+  end
+
+  describe "status_checks_passed?" do
+    let(:status_url) { "#{GithubMergeSign::PullRequest::BASE_URL}/example/test-repo/commits/#{pr_commit_id}/status" }
+
+    before :each do
+      stub_pr_details("head" => { "sha" => pr_commit_id })
+    end
+
+    it "is true when Github reports that all checks have succeeded" do
+      WebMock.stub_request(:get, status_url)
+        .to_return(
+          headers: { "Content-Type" => "application/json" },
+          body: { "state" => "success" }.to_json,
+        )
+
+      expect(pull_request.status_checks_passed?).to eq(true)
+    end
+
+    it "is true when there are no status checks" do
+      WebMock.stub_request(:get, status_url)
+        .to_return(
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "state" => "pending",
+            "statuses" => [],
+          }.to_json,
+        )
+
+      expect(pull_request.status_checks_passed?).to eq(true)
+    end
+
+    it "is false otherwise" do
+      WebMock.stub_request(:get, status_url)
+        .to_return(
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "state" => "pending",
+            "statuses" => [:something],
+          }.to_json,
+        )
+
+      expect(pull_request.status_checks_passed?).to eq(false)
+    end
+  end
+
+  describe "external_pr?" do
+    it "is false when the head and the base reference the same repo" do
+      stub_pr_details("title" => "[#1234] A nice PR",
+        "head" => {
+          "repo" => {
+            "full_name" => repo,
+          },
+        },
+        "base" => {
+          "repo" => {
+            "full_name" => repo,
+          },
+        })
+
+      expect(pull_request.external_pr?).to eq(false)
+    end
+
+    it "is true otherwise" do
+      stub_pr_details("title" => "[#1234] A nice PR",
+        "head" => {
+          "repo" => {
+            "full_name" => "elsewhere/test",
+          },
+        },
+        "base" => {
+          "repo" => {
+            "full_name" => repo,
+          },
+        })
+
+      expect(pull_request.external_pr?).to eq(true)
+    end
+  end
+
+  describe "target_branch" do
+    it "returns the target branch from the PR details" do
+      stub_pr_details("title" => "[#1234] A nice PR",
+        "base" => {
+          "ref" => "target_branch",
+        })
+
+      expect(pull_request.target_branch).to eq("target_branch")
+    end
+  end
+
+  describe "merge commit message" do
+    it "should populate the commit message with details from the PR" do
+      stub_pr_details("title" => "[#1234] A nice PR",
+        "head" => {
+          "ref" => "nice_pr",
+          "user" => {
+            "login" => "example",
+          },
+        })
+
+      expect(pull_request.commit_message).to eq(<<-EOT)
+Merge pull request #1 from example/nice_pr
+
+[#1234] A nice PR
+      EOT
+    end
+  end
+
+  it "returns an error if the PR doesn't exist" do
+    WebMock.stub_request(:get, "#{GithubMergeSign::PullRequest::BASE_URL}/#{repo}/pulls/1")
+      .to_return(
+        status: 404,
+        headers: { "Content-Type" => "application/json" },
+        body: { "message" => "Not Found" }.to_json,
+      )
+
+    expect {
+      pull_request.open?
+    }.to raise_error(/Failed to fetch PR details/)
+  end
+
+  describe "merge!" do
+    def allow_command(command, success = true)
+      allow(Kernel).to receive(:system).with(command).and_return(success)
+    end
+
+    def expect_command(*command)
+      expect(Kernel).to receive(:system).with(*command).and_return(true)
+    end
+
+    def refute_command(*command)
+      expect(Kernel).not_to receive(:system).with(*command)
+    end
+
+    before(:each) do
+      allow_command('git diff --quiet --exit-code HEAD')
+
+      allow(pull_request).to receive_messages(
+        open?: true,
+        mergeable?: true,
+        status_checks_passed?: true,
+        external_pr?: false,
+        target_branch: "master",
+        head_commit_id: pr_commit_id,
+        head_ref: "pr_branch",
+        commit_message: "Dummy commit message\n\nWith multiple lines\n",
+      )
+    end
+
+    it "raises an error if the PR isn't open" do
+      allow(pull_request).to receive_messages(open?: false)
+      expect {
+        pull_request.merge!
+      }.to raise_error(/is not open/)
+    end
+
+    it "raises an error if the PR isn't mergeable" do
+      allow(pull_request).to receive_messages(mergeable?: false)
+      expect {
+        pull_request.merge!
+      }.to raise_error(/is not mergeable/)
+    end
+
+    it "raises an error if the status checks haven't passed" do
+      allow(pull_request).to receive_messages(status_checks_passed?: false)
+      expect {
+        pull_request.merge!
+      }.to raise_error(/has not passed all status checks/)
+    end
+
+    it "raises an error when the working directory isn't clean" do
+      allow_command('git diff --quiet --exit-code HEAD', false)
+
+      expect {
+        pull_request.merge!
+      }.to raise_error(/Working directory is not clean/)
+    end
+
+    it "switches to master, and merges the relevant commit" do
+      expect_command('git checkout master')
+      expect_command('git pull --ff-only origin master')
+      expect_command('git', 'merge', '--no-ff', '-S', '-m', "Dummy commit message\n\nWith multiple lines\n", pr_commit_id)
+      expect_command('git push origin master')
+      expect_command('git push origin :pr_branch')
+
+      pull_request.merge!
+    end
+
+    context "when the target branch isn't master" do
+      before :each do
+        allow(pull_request).to receive_messages(target_branch: "another_branch")
+      end
+
+      it "switches to the target_branch, and merges the relevant commit" do
+        expect_command('git checkout another_branch')
+        expect_command('git pull --ff-only origin another_branch')
+        expect_command('git', 'merge', '--no-ff', '-S', '-m', "Dummy commit message\n\nWith multiple lines\n", pr_commit_id)
+        expect_command('git push origin another_branch')
+        expect_command('git push origin :pr_branch')
+
+        pull_request.merge!
+      end
+    end
+
+    context "a PR from a different fork of our repo" do
+      before :each do
+        allow(pull_request).to receive_messages(external_pr?: true)
+      end
+
+      it "fetches the commits for the PR and doesn't delete the remote branch" do
+        expect_command('git checkout master')
+        expect_command('git pull --ff-only origin master')
+        expect_command('git fetch origin refs/pull/1/head')
+        expect_command('git', 'merge', '--no-ff', '-S', '-m', "Dummy commit message\n\nWith multiple lines\n", pr_commit_id)
+        expect_command('git push origin master')
+
+        refute_command('git push origin :pr_branch')
+
+        pull_request.merge!
+      end
+    end
+
+    it "raises an error if one of the git commands errors" do
+      expect_command('git checkout master')
+      expect(Kernel).to receive(:system).with('git pull --ff-only origin master') { system("exit 3") }
+
+      expect {
+        pull_request.merge!
+      }.to raise_error(/exited 3/)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,3 +9,5 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
+
+require 'webmock/rspec'


### PR DESCRIPTION
## What

This extracts the script to merge and GPG sign a PR from paas-cf into this gem.

We're starting to use this in more places, so it makes sense to maintain this separately. There has also been interest in this from other teams.

## How to review

* Code review - verify that the code matches the version at https://github.com/alphagov/paas-cf/tree/811da92

Optionally use this to merge a PR as follows:

* install the gem locally by doing `bundle exec rake install`
* Merge a PR using `github_merge_sign --pr N` in the local checkout of the corresponding repo.
* cleanup installed gem - `gem uninstall github_merge_sign`

## Who can review

Not me.