### PR TITLE
Enable Travis publishing of gem to rubygems.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,11 @@ language: ruby
 rvm:
   - "2.3"
   - "2.4"
+deploy:
+  provider: rubygems
+  api_key:
+    secure: L/mmeonwxNIiMqHs1o2gw47jJOXHFChTbBxfy3anW/TFi5EipybyBXrT7dikUqgzYpzVdiomLEvJjIeR0hlt3oBGaCddpGaXF/2keEeSpOB2xhpCZIIFnUN+5g3VgVHiU5yC1SeKZzxyoA1UocHl+q0wXAcmeHhKgNpVjp98MxwLGos85BkLbqiIx8PG5nM3QWF//uVm8tO0ISkGT0inuPfNa/OThHDyHdZ1a6AqpbZHecZm1yd9FE3KkwGTQMftKrrMh/Ttv6ACCS8b6fu2x9gO+JyslJNX0D+o3rirjEgfdJqXKNmEl4vCPrzx4mpuKSamvWVNtE4ZgCoM7c8f+qHbvSCC5FyXUqPYWqsGfYma1eqsV/yMtWZCCbrUHysWoMs6F5f3+JdBWajEM8BqkvGgCJTtGQLOj6HfbvXXfDyXkMiFU/kTuDaZRD4BAKy870THLpj51jDG0fpWGdUNJVUloF6o1tOqRARBNPXmrKMWCP1fjz5irXvX9wyZpaAwOTBkQLlLUHdDRcXcRiwY5dkxUhzBXB6OcOqRLYUuP/okrgaQghK7cGv7SD/0T3+Zwie6uFgkSn7kAxfWwUHGb74yO+MbIXvDxxhKHKBvPMKOraSDUrL8Uu98UD79Jdlgn70GD/xZS5hSe9Sbmg/Irn3BNu2fBA0eEyd0LwejG6w=
+  on:
+    tags: true
+    # pin to a ruby version to prevent multiple publish attempts.
+    ruby: "2.4"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+* Initial version

--- a/README.md
+++ b/README.md
@@ -28,7 +28,18 @@ TODO: Write usage instructions here
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`.
+
+This gem is versioned following [Semantic Versioning](http://semver.org/) as
+described in the [GDS rubygems
+styleguide](https://github.com/alphagov/styleguides/blob/master/rubygems.md#versioning).
+To release a new version, update the version number in
+`lib/github_merge_sign/version.rb`, update `CHANGELOG.md` and create a PR for
+this version change.
+
+Once this PR is merged, tag the merge commit with the version number, and push
+the tag. This will cause Travis to build and publish the gem to
+[rubygems.org](https://rubygems.org).
 
 ## Contributing
 


### PR DESCRIPTION
## What

This configures Travis to publish the gem to rubygems.org

This contains the encrypted API key for the gds-paas rubygems.org user
(creds in the high cred store).

This is configured to only publish on git tags. This will result in a
workflow where we tag master when we're ready to publish a version.

It's necessary to pin to a specific ruby version, otherwise Travis will
attempt to publish multiple times for each tag push (once for each ruby
version sub-build).

## How to review

I'm not sure the best way to review this without testing publishing a gem for real.

Some things that could be tested:
* read the [Travis docs on deploying](https://docs.travis-ci.com/user/deployment/rubygems/), and verifying that this matches.
* Verify that Travis doesn't attempt to publish from this PR branch build.

I've used config like this on some of my gems (eg https://github.com/alext/rack_strip_client_ip) which can be used for comparison.

## Who can review

Not me.