### PR TITLE
Update for releasing version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## Unreleased
+## 1.0.0
 
-* Initial version
+* Initial version extracted from github.com/alphagov/paas-cf

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ To release a new version, update the version number in
 `lib/github_merge_sign/version.rb`, update `CHANGELOG.md` and create a PR for
 this version change.
 
-Once this PR is merged, tag the merge commit with the version number, and push
-the tag. This will cause Travis to build and publish the gem to
-[rubygems.org](https://rubygems.org).
+Once this PR is merged, tag the merge commit with the version number prefixed
+with 'v' (eg 'v1.4.2'), and push the tag. This will cause Travis to build and
+publish the gem to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/lib/github_merge_sign/version.rb
+++ b/lib/github_merge_sign/version.rb
@@ -1,3 +1,3 @@
 module GithubMergeSign
-  VERSION = "0.1.0.test2"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
## What

Changes to bump version to 1.0.0

This code has been in use for a while, and merely repackaged in a gem
here. It therefore makes sense to release this as 1.0.0 and immediately
start following all of semver.

## How to review

Code review. Verify that the intended version makes sense.

Once merged, I will tag the merge commit which will cause Travis to release this to rubygems.org

## Who can review

Not me.