### PR TITLE
Update ruby version, dependencies, and usage of GitHub API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ dist: focal
 sudo: false
 language: ruby
 rvm:
-  - "2.4"
-  - "2.5"
-  - "2.6"
+  - "2.7"
 deploy:
   provider: rubygems
   api_key:
@@ -13,4 +11,4 @@ deploy:
   on:
     tags: true
     # pin to a ruby version to prevent multiple publish attempts.
-    ruby: "2.6"
+    ruby: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 sudo: false
 language: ruby
 rvm:

--- a/github_merge_sign.gemspec
+++ b/github_merge_sign.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 3.0"

--- a/github_merge_sign.gemspec
+++ b/github_merge_sign.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 2"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "webmock", "~> 3.0"
+  spec.add_development_dependency "rake", "~> 12"
+  spec.add_development_dependency "rspec", "~> 3"
+  spec.add_development_dependency "webmock", "~> 3"
 end

--- a/lib/github_merge_sign.rb
+++ b/lib/github_merge_sign.rb
@@ -135,11 +135,9 @@ Merge pull request ##{@pr_number} from #{details.fetch('head').fetch('user').fet
 
     def http_get(url)
       uri = URI.parse(url)
-      if ENV["GITHUB_API_TOKEN"]
-        uri.query = [uri.query, "access_token=#{ENV['GITHUB_API_TOKEN']}"].compact.join('&')
-      end
       Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
         request = Net::HTTP::Get.new(uri.request_uri)
+        request['Authorization'] = "token #{ENV['GITHUB_API_TOKEN']}" if ENV["GITHUB_API_TOKEN"]
         return http.request(request)
       end
     end

--- a/spec/pull_request_spec.rb
+++ b/spec/pull_request_spec.rb
@@ -20,8 +20,15 @@ RSpec.describe GithubMergeSign::PullRequest do
 
   def stub_pr_details(details, options = {})
     url = "#{GithubMergeSign::PullRequest::BASE_URL}/#{repo}/pulls/1"
-    url << "?access_token=#{options[:token]}" if options[:token]
+
+    headers = {
+      'Accept'=>'*/*',
+      'User-Agent'=>'Ruby'
+    }
+    headers['Authorization'] = "token #{options[:token]}" if options[:token]
+
     WebMock.stub_request(:get, url)
+      .with(headers: headers)
       .to_return(
         headers: { "Content-Type" => "application/json" },
         body: details.to_json,
@@ -52,13 +59,9 @@ RSpec.describe GithubMergeSign::PullRequest do
     end
 
     it "should add an access token to API requests" do
-      stub_without_token = stub_pr_details("state" => "open")
       stub_with_token = stub_pr_details({ "state" => "open" }, token: "1234567890")
-
       pull_request.open?
-
       expect(stub_with_token).to have_been_requested
-      expect(stub_without_token).not_to have_been_requested
     end
   end
 


### PR DESCRIPTION
1. GitHub API does not allow `access_token` as a query parameter anymore
2. Ruby 2.7
3. Use updated Rake and friends

Tested this manually